### PR TITLE
Opt-in keep test-compile before package

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ mvn clean verify -b turbo
 To enable this extension by default, add line to `.mvn/maven.config` under root of your project:
 ```
 -bturbo
+-T1C
 ```
 
 Example adoption:

--- a/src/main/java/com/github/seregamorph/maven/turbo/DefaultLifecyclePatcher.java
+++ b/src/main/java/com/github/seregamorph/maven/turbo/DefaultLifecyclePatcher.java
@@ -80,7 +80,7 @@ class DefaultLifecyclePatcher {
         for (int i = 0; i < phases.size(); i++) {
             String lifecyclePhase = phases.get(i);
             if (firstTestPhaseIndex < 0
-                    && (config.isSupportTestJar() ? isTest(lifecyclePhase) : isAnyTest(lifecyclePhase))) {
+                && (config.isTurboTestCompile() ? isTest(lifecyclePhase) : isAnyTest(lifecyclePhase))) {
                 firstTestPhaseIndex = i;
             }
             if (isPackage(lifecyclePhase)) {
@@ -94,7 +94,7 @@ class DefaultLifecyclePatcher {
 
     static boolean isPackage(String phase) {
         return Arrays.asList("prepare-package", "package")
-                .contains(phase);
+            .contains(phase);
     }
 
     private static boolean isTest(String phase) {
@@ -107,9 +107,9 @@ class DefaultLifecyclePatcher {
         // "test-compile", "process-test-classes", "test", "pre-integration-test", "integration-test",
         // "post-integration-test"
         return "test".equals(phase)
-                || phase.contains("-test-")
-                || phase.startsWith("test-")
-                || phase.endsWith("-test");
+            || phase.contains("-test-")
+            || phase.startsWith("test-")
+            || phase.endsWith("-test");
     }
 
     private DefaultLifecyclePatcher() {

--- a/src/main/java/com/github/seregamorph/maven/turbo/DefaultLifecyclePatcher.java
+++ b/src/main/java/com/github/seregamorph/maven/turbo/DefaultLifecyclePatcher.java
@@ -9,6 +9,7 @@ import java.util.List;
  */
 class DefaultLifecyclePatcher {
 /*
+    If test-jar is not supported:
     original phases of the default lifecycle [
         "validate",
         "initialize",
@@ -20,13 +21,45 @@ class DefaultLifecyclePatcher {
         "process-classes",
 
      |==>
-     |   "generate-test-sources",
-     |   "process-test-sources",
-     |   "generate-test-resources",
-     |   "process-test-resources",
-     |   "test-compile",
-     |   "process-test-classes",
-     |   "test",
+     |  "generate-test-sources",
+     |  "process-test-sources",
+     |  "generate-test-resources",
+     |  "process-test-resources",
+     |  "test-compile",
+     |  "process-test-classes",
+     |  "test",
+     |
+     |  // moved before "*test*" phases
+     |= "prepare-package",
+     |= "package",
+
+        "pre-integration-test",
+        "integration-test",
+        "post-integration-test",
+        "verify",
+        "install",
+        "deploy"
+    ]
+
+    If test-jar is supported
+    original phases of the default lifecycle [
+        "validate",
+        "initialize",
+        "generate-sources",
+        "process-sources",
+        "generate-resources",
+        "process-resources",
+        "compile",
+        "process-classes",
+
+        "generate-test-sources",
+        "process-test-sources",
+        "generate-test-resources",
+        "process-test-resources",
+        "test-compile",
+        "process-test-classes",
+     |==>
+     |  "test",
      |
      |  // moved before "*test*" phases
      |= "prepare-package",
@@ -41,12 +74,13 @@ class DefaultLifecyclePatcher {
     ]
 */
 
-    static void patchDefaultLifecycle(List<String> phases) {
+    static void patchDefaultLifecycle(TurboBuilderConfig config, List<String> phases) {
         List<String> packagePhases = new ArrayList<>();
         int firstTestPhaseIndex = -1;
         for (int i = 0; i < phases.size(); i++) {
             String lifecyclePhase = phases.get(i);
-            if (firstTestPhaseIndex < 0 && isTest(lifecyclePhase)) {
+            if (firstTestPhaseIndex < 0
+                    && (config.isSupportTestJar() ? isTest(lifecyclePhase) : isAnyTest(lifecyclePhase))) {
                 firstTestPhaseIndex = i;
             }
             if (isPackage(lifecyclePhase)) {
@@ -60,17 +94,22 @@ class DefaultLifecyclePatcher {
 
     static boolean isPackage(String phase) {
         return Arrays.asList("prepare-package", "package")
-            .contains(phase);
+                .contains(phase);
     }
 
-    static boolean isTest(String phase) {
+    private static boolean isTest(String phase) {
+        // "test"
+        return "test".equals(phase);
+    }
+
+    static boolean isAnyTest(String phase) {
         // "generate-test-sources", "process-test-sources", "generate-test-resources", "process-test-resources",
         // "test-compile", "process-test-classes", "test", "pre-integration-test", "integration-test",
         // "post-integration-test"
         return "test".equals(phase)
-            || phase.contains("-test-")
-            || phase.startsWith("test-")
-            || phase.endsWith("-test");
+                || phase.contains("-test-")
+                || phase.startsWith("test-")
+                || phase.endsWith("-test");
     }
 
     private DefaultLifecyclePatcher() {

--- a/src/main/java/com/github/seregamorph/maven/turbo/TurboBuilder.java
+++ b/src/main/java/com/github/seregamorph/maven/turbo/TurboBuilder.java
@@ -1,18 +1,34 @@
 package com.github.seregamorph.maven.turbo;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.lifecycle.DefaultLifecycles;
-import org.apache.maven.lifecycle.internal.*;
+import org.apache.maven.lifecycle.internal.BuildThreadFactory;
+import org.apache.maven.lifecycle.internal.LifecycleModuleBuilder;
+import org.apache.maven.lifecycle.internal.ProjectBuildList;
+import org.apache.maven.lifecycle.internal.ProjectSegment;
+import org.apache.maven.lifecycle.internal.ReactorBuildStatus;
+import org.apache.maven.lifecycle.internal.ReactorContext;
+import org.apache.maven.lifecycle.internal.TaskSegment;
 import org.apache.maven.lifecycle.internal.builder.Builder;
 import org.apache.maven.lifecycle.internal.builder.multithreaded.ConcurrencyDependencyGraph;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.logging.Logger;
-
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
-import java.util.*;
-import java.util.concurrent.*;
 
 /**
  * Custom maven project builder. It's rewritten from original

--- a/src/main/java/com/github/seregamorph/maven/turbo/TurboBuilder.java
+++ b/src/main/java/com/github/seregamorph/maven/turbo/TurboBuilder.java
@@ -1,34 +1,18 @@
 package com.github.seregamorph.maven.turbo;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.PriorityBlockingQueue;
-import java.util.concurrent.RunnableFuture;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.lifecycle.DefaultLifecycles;
-import org.apache.maven.lifecycle.internal.BuildThreadFactory;
-import org.apache.maven.lifecycle.internal.LifecycleModuleBuilder;
-import org.apache.maven.lifecycle.internal.ProjectBuildList;
-import org.apache.maven.lifecycle.internal.ProjectSegment;
-import org.apache.maven.lifecycle.internal.ReactorBuildStatus;
-import org.apache.maven.lifecycle.internal.ReactorContext;
-import org.apache.maven.lifecycle.internal.TaskSegment;
+import org.apache.maven.lifecycle.internal.*;
 import org.apache.maven.lifecycle.internal.builder.Builder;
 import org.apache.maven.lifecycle.internal.builder.multithreaded.ConcurrencyDependencyGraph;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.logging.Logger;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.*;
+import java.util.concurrent.*;
 
 /**
  * Custom maven project builder. It's rewritten from original
@@ -54,6 +38,7 @@ public class TurboBuilder implements Builder {
     public TurboBuilder(
             DefaultLifecycles defaultLifeCycles,
             LifecycleModuleBuilder lifecycleModuleBuilder,
+            TurboBuilderConfig config,
             Logger logger
     ) {
         this.lifecycleModuleBuilder = lifecycleModuleBuilder;
@@ -63,7 +48,7 @@ public class TurboBuilder implements Builder {
         defaultLifeCycles.getLifeCycles().forEach(lifecycle -> {
             if ("default".equals(lifecycle.getId())) {
                 logger.warn("Turbo builder: patching default lifecycle 🏎️ (reorder package and test phases)");
-                DefaultLifecyclePatcher.patchDefaultLifecycle(lifecycle.getPhases());
+                DefaultLifecyclePatcher.patchDefaultLifecycle(config, lifecycle.getPhases());
             }
         });
     }

--- a/src/main/java/com/github/seregamorph/maven/turbo/TurboBuilderConfig.java
+++ b/src/main/java/com/github/seregamorph/maven/turbo/TurboBuilderConfig.java
@@ -1,34 +1,33 @@
 package com.github.seregamorph.maven.turbo;
 
-import org.apache.maven.execution.MavenSession;
-
 import javax.inject.Inject;
+import org.apache.maven.execution.MavenSession;
 
 /**
  * @author Sergey Chernov
  */
 public class TurboBuilderConfig {
 
-    private final boolean supportTestJar;
+    private final boolean turboTestCompile;
 
     @Inject
     public TurboBuilderConfig(MavenSession session) {
-        String supportTestJar = session.getSystemProperties().getProperty("supportTestJar");
-        this.supportTestJar = MavenPropertyUtils.isEmptyOrTrue(supportTestJar);
+        String turboTestCompile = session.getSystemProperties().getProperty("turboTestCompile");
+        this.turboTestCompile = MavenPropertyUtils.isEmptyOrTrue(turboTestCompile);
     }
 
-    TurboBuilderConfig(boolean supportTestJar) {
-        this.supportTestJar = supportTestJar;
+    TurboBuilderConfig(boolean turboTestCompile) {
+        this.turboTestCompile = turboTestCompile;
     }
 
-    public boolean isSupportTestJar() {
-        return supportTestJar;
+    public boolean isTurboTestCompile() {
+        return turboTestCompile;
     }
 
     @Override
     public String toString() {
         return "TurboBuilderConfig{" +
-            "supportTestJar=" + supportTestJar +
+            "turboTestCompile=" + turboTestCompile +
             '}';
     }
 }

--- a/src/main/java/com/github/seregamorph/maven/turbo/TurboBuilderConfig.java
+++ b/src/main/java/com/github/seregamorph/maven/turbo/TurboBuilderConfig.java
@@ -1,0 +1,34 @@
+package com.github.seregamorph.maven.turbo;
+
+import org.apache.maven.execution.MavenSession;
+
+import javax.inject.Inject;
+
+/**
+ * @author Sergey Chernov
+ */
+public class TurboBuilderConfig {
+
+    private final boolean supportTestJar;
+
+    @Inject
+    public TurboBuilderConfig(MavenSession session) {
+        String supportTestJar = session.getSystemProperties().getProperty("supportTestJar");
+        this.supportTestJar = MavenPropertyUtils.isEmptyOrTrue(supportTestJar);
+    }
+
+    TurboBuilderConfig(boolean supportTestJar) {
+        this.supportTestJar = supportTestJar;
+    }
+
+    public boolean isSupportTestJar() {
+        return supportTestJar;
+    }
+
+    @Override
+    public String toString() {
+        return "TurboBuilderConfig{" +
+            "supportTestJar=" + supportTestJar +
+            '}';
+    }
+}

--- a/src/main/java/com/github/seregamorph/maven/turbo/TurboMavenLifecycleParticipant.java
+++ b/src/main/java/com/github/seregamorph/maven/turbo/TurboMavenLifecycleParticipant.java
@@ -1,5 +1,9 @@
 package com.github.seregamorph.maven.turbo;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Named;
 import org.apache.maven.AbstractMavenLifecycleParticipant;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.SessionScoped;
@@ -9,11 +13,6 @@ import org.apache.maven.model.PluginExecution;
 import org.apache.maven.project.MavenProject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.inject.Inject;
-import javax.inject.Named;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Build start / finish interceptor that prints a warning to avoid confusion.
@@ -38,7 +37,7 @@ public class TurboMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
 
     @Override
     public void afterProjectsRead(MavenSession session) throws MavenExecutionException {
-        if (isIsTurboBuilder(session)) {
+        if (isTurboBuilder(session)) {
             checkTestJarArtifacts(session);
             checkBuilderAndPhase(session);
         }
@@ -46,33 +45,33 @@ public class TurboMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
 
     @Override
     public void afterSessionEnd(MavenSession session) {
-        if (isIsTurboBuilder(session)) {
+        if (isTurboBuilder(session)) {
             checkBuilderAndPhase(session);
         }
     }
 
     private void checkTestJarArtifacts(MavenSession session) throws MavenExecutionException {
-        if (!config.isSupportTestJar()) {
+        if (!config.isTurboTestCompile()) {
             // test-jar is not supported, because package phase is now executed before compiling tests
             for (MavenProject project : session.getProjects()) {
                 List<Plugin> jarPlugins = project.getBuildPlugins().stream()
-                        .filter(plugin ->
-                                "org.apache.maven.plugins".equals(plugin.getGroupId())
-                                        && "maven-jar-plugin".equals(plugin.getArtifactId()))
-                        .collect(Collectors.toList());
+                    .filter(plugin ->
+                        "org.apache.maven.plugins".equals(plugin.getGroupId())
+                            && "maven-jar-plugin".equals(plugin.getArtifactId()))
+                    .collect(Collectors.toList());
                 for (Plugin jarPlugin : jarPlugins) {
                     for (PluginExecution pluginExecution : jarPlugin.getExecutions()) {
                         if (pluginExecution.getGoals().contains("test-jar")) {
                             throw new MavenExecutionException("Maven started with turbo builder (`-b turbo` CLI "
-                                    + "parameter or `-bturbo` in .mvn/maven.config) and it's not compatible with " + project
-                                    + " test-jar project artifacts and dependencies because of build phase reordering "
-                                    + "(package phase is now executed before compiling tests). The maven-jar-plugin "
-                                    + "configuration of the project has configured `test-jar` goal.\n"
-                                    + "This can be solved in several ways:\n"
-                                    + "1. Get rid of test-jar packaging if possible\n"
-                                    + "2. Opt-in support of test-jar packaging via `-DsupportTestJar` CLI parameter "
-                                    + "or specified in .mvn/maven.config on a separate line",
-                                    project.getFile());
+                                + "parameter or `-bturbo` in .mvn/maven.config) and it's not compatible with " + project
+                                + " test-jar project artifacts and dependencies because of build phase reordering "
+                                + "(package phase is now executed before compiling tests). The maven-jar-plugin "
+                                + "configuration of the project has configured `test-jar` goal.\n"
+                                + "This can be solved in several ways:\n"
+                                + "1. Get rid of test-jar packaging if possible\n"
+                                + "2. Opt-in support of test-jar packaging via `-DturboTestCompile` CLI parameter "
+                                + "or specified in .mvn/maven.config on a separate line",
+                                project.getFile());
                         }
                     }
                 }
@@ -80,17 +79,35 @@ public class TurboMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
         }
     }
 
-    private static void checkBuilderAndPhase(MavenSession session) {
-        if (session.getRequest().getGoals().contains("package")) {
-            logger.warn("package phase is requested in combination with turbo builder (`-bturbo` parameter \n"
+    private void checkBuilderAndPhase(MavenSession session) {
+        // skip both compiling and running tests
+        boolean mavenTestSkip = MavenPropertyUtils.isEmptyOrTrue(session.getSystemProperties()
+            .getProperty("maven.test.skip"));
+        // skip only running tests
+        boolean skipTests = MavenPropertyUtils.isEmptyOrTrue(session.getSystemProperties().getProperty("skipTests"));
+        String skippedReorderedPhases;
+        if (mavenTestSkip) {
+            // If there is `-Dmaven.test.skip`, don't bother with warning
+            skippedReorderedPhases = null;
+        } else {
+            if (config.isTurboTestCompile()) {
+                skippedReorderedPhases = skipTests ? null : "running";
+            } else {
+                skippedReorderedPhases = skipTests ? "compiling" : "compiling and running";
+            }
+        }
+        if (skippedReorderedPhases != null && session.getRequest().getGoals().contains("package")) {
+            logger.warn("package phase is requested in combination with turbo builder (`-bturbo` parameter "
                     + "in the command line or .mvn/maven.config). Please note, that\n"
-                    + ANSI_RED + "compiling and running tests is not included in the execution" + ANSI_RESET + "\n"
-                    + "because of phase reordering.\n"
-                    + "To run tests, use `test`, `verify` or `install` phase instead of `package`.");
+                    + ANSI_RED + "{} tests is not included in the execution" + ANSI_RESET
+                    + " because of phase reordering.\n"
+                    + "{}To run tests, use `test`, `verify` or `install` phase instead of `package`.",
+                skippedReorderedPhases,
+                config.isTurboTestCompile() ? "" : "To compile tests, run with parameter `-DturboTestCompile`.\n");
         }
     }
 
-    private static boolean isIsTurboBuilder(MavenSession session) {
+    private static boolean isTurboBuilder(MavenSession session) {
         String builderId = session.getRequest().getBuilderId();
         return TurboBuilder.BUILDER_TURBO.equals(builderId);
     }

--- a/src/main/java/com/github/seregamorph/maven/turbo/TurboMojosExecutionStrategy.java
+++ b/src/main/java/com/github/seregamorph/maven/turbo/TurboMojosExecutionStrategy.java
@@ -1,7 +1,7 @@
 package com.github.seregamorph.maven.turbo;
 
+import static com.github.seregamorph.maven.turbo.DefaultLifecyclePatcher.isAnyTest;
 import static com.github.seregamorph.maven.turbo.DefaultLifecyclePatcher.isPackage;
-import static com.github.seregamorph.maven.turbo.DefaultLifecyclePatcher.isTest;
 import static com.github.seregamorph.maven.turbo.MavenPropertyUtils.getProperty;
 import static com.github.seregamorph.maven.turbo.MavenPropertyUtils.isEmptyOrTrue;
 
@@ -49,7 +49,7 @@ public class TurboMojosExecutionStrategy implements MojosExecutionStrategy {
                         phase = mojoDescriptor.getPhase();
                     }
                 }
-                if (phase != null && isTest(phase)) {
+                if (phase != null && isAnyTest(phase)) {
                     signaled = true;
                     // signal before tests
                     SignalingExecutorCompletionService.signal(currentProject);

--- a/src/main/resources/META-INF/sisu/javax.inject.Named
+++ b/src/main/resources/META-INF/sisu/javax.inject.Named
@@ -1,3 +1,4 @@
 com.github.seregamorph.maven.turbo.DelegatingMojosExecutionStrategy
 com.github.seregamorph.maven.turbo.TurboBuilder
+com.github.seregamorph.maven.turbo.TurboBuilderConfig
 com.github.seregamorph.maven.turbo.TurboMavenLifecycleParticipant

--- a/src/test/java/com/github/seregamorph/maven/turbo/DefaultLifecyclePatcherTest.java
+++ b/src/test/java/com/github/seregamorph/maven/turbo/DefaultLifecyclePatcherTest.java
@@ -1,10 +1,11 @@
 package com.github.seregamorph.maven.turbo;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Sergey Chernov
@@ -12,7 +13,7 @@ import org.junit.jupiter.api.Test;
 class DefaultLifecyclePatcherTest {
 
     @Test
-    public void shouldPatchDefaultLifecycle() {
+    public void shouldPatchDefaultLifecycleNoTestJarSupported() {
         var phases = new ArrayList<>(List.of(
             "validate",
             "initialize",
@@ -38,7 +39,7 @@ class DefaultLifecyclePatcherTest {
             "install",
             "deploy"
         ));
-        DefaultLifecyclePatcher.patchDefaultLifecycle(phases);
+        DefaultLifecyclePatcher.patchDefaultLifecycle(new TurboBuilderConfig(false), phases);
         assertEquals(List.of(
             "validate",
             "initialize",
@@ -56,6 +57,61 @@ class DefaultLifecyclePatcherTest {
             "process-test-resources",
             "test-compile",
             "process-test-classes",
+            "test",
+            "pre-integration-test",
+            "integration-test",
+            "post-integration-test",
+            "verify",
+            "install",
+            "deploy"
+        ), phases);
+    }
+
+    @Test
+    public void shouldPatchDefaultLifecycleTestJarSupported() {
+        var phases = new ArrayList<>(List.of(
+            "validate",
+            "initialize",
+            "generate-sources",
+            "process-sources",
+            "generate-resources",
+            "process-resources",
+            "compile",
+            "process-classes",
+            "generate-test-sources",
+            "process-test-sources",
+            "generate-test-resources",
+            "process-test-resources",
+            "test-compile",
+            "process-test-classes",
+            "test",
+            "prepare-package",
+            "package",
+            "pre-integration-test",
+            "integration-test",
+            "post-integration-test",
+            "verify",
+            "install",
+            "deploy"
+        ));
+        DefaultLifecyclePatcher.patchDefaultLifecycle(new TurboBuilderConfig(true), phases);
+        assertEquals(List.of(
+            "validate",
+            "initialize",
+            "generate-sources",
+            "process-sources",
+            "generate-resources",
+            "process-resources",
+            "compile",
+            "process-classes",
+            "generate-test-sources",
+            "process-test-sources",
+            "generate-test-resources",
+            "process-test-resources",
+            "test-compile",
+            "process-test-classes",
+            "prepare-package",
+            "package",
             "test",
             "pre-integration-test",
             "integration-test",

--- a/src/test/java/com/github/seregamorph/maven/turbo/TurboMojosExecutionStrategyTest.java
+++ b/src/test/java/com/github/seregamorph/maven/turbo/TurboMojosExecutionStrategyTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 class TurboMojosExecutionStrategyTest {
 
     @Test
-    public void shouldReorderAndSignalFullPhases() throws LifecycleExecutionException {
+    public void shouldReorderAndSignalFullPhasesNoTestJarSupported() throws LifecycleExecutionException {
         List<String> phases = List.of(
             "validate",
             "initialize",
@@ -72,12 +72,68 @@ class TurboMojosExecutionStrategyTest {
             "exec:install",
             "exec:deploy"
         );
-
         shouldReorderAndSignalImpl(phases, expectedEvents);
     }
 
     @Test
-    public void shouldReorderAndSignalSubsetPhases() throws LifecycleExecutionException {
+    public void shouldReorderAndSignalFullPhasesTestJarSupported() throws LifecycleExecutionException {
+        List<String> phases = List.of(
+            "validate",
+            "initialize",
+            "generate-sources",
+            "process-sources",
+            "generate-resources",
+            "process-resources",
+            "compile",
+            "process-classes",
+            "generate-test-sources",
+            "process-test-sources",
+            "generate-test-resources",
+            "process-test-resources",
+            "test-compile",
+            "process-test-classes",
+            // note: already reordered before test phases
+            "prepare-package",
+            "package",
+            "test",
+            "pre-integration-test",
+            "integration-test",
+            "post-integration-test",
+            "verify",
+            "install",
+            "deploy"
+        );
+        var expectedEvents = List.of(
+            "exec:validate",
+            "exec:initialize",
+            "exec:generate-sources",
+            "exec:process-sources",
+            "exec:generate-resources",
+            "exec:process-resources",
+            "exec:compile",
+            "exec:process-classes",
+            "exec:generate-test-sources",
+            "exec:process-test-sources",
+            "exec:generate-test-resources",
+            "exec:process-test-resources",
+            "exec:test-compile",
+            "exec:process-test-classes",
+            "exec:prepare-package",
+            "exec:package",
+            "signal",
+            "exec:test",
+            "exec:pre-integration-test",
+            "exec:integration-test",
+            "exec:post-integration-test",
+            "exec:verify",
+            "exec:install",
+            "exec:deploy"
+        );
+        shouldReorderAndSignalImpl(phases, expectedEvents);
+    }
+
+    @Test
+    public void shouldReorderAndSignalSubsetPhasesNoTestJarSupported() throws LifecycleExecutionException {
         List<String> phases = List.of(
             "validate",
             "initialize",


### PR DESCRIPTION
#2 There is an interesting question, which order of phases is better.
Latest `0.7` version has order `[compile, package, test-compile, test, integration-test, verify, install, deploy]`: `prepare-package` and `package` moved before `test-compile` and `test` (some phases omitted to be concise).

It has an implicit side effect: if the command is `mvn package`, now the test compilation is skipped. This can be fine, but can confuse as well. This can be solved by changing the command to `mvn test-compile` or `mvn install` which is also confusing and also usually not recommended. The problem is that phases are patched only when `-b turbo` parameter is added, so these changes should be done in combination (enable builder and change the requested phase).

This PR is opt-in with phase order `[compile, test-compile, package, test..]`: `package` is before `test`, but after `test-compile`. Note that it's not the same as current impl `package` before `test-compile`. This will reduce the optimization effect a bit (especially if there is only a compilation), but if the elephant in the room is running surefire/failsafe, that's still a huge boost.

<img width="721" alt="Screenshot 2025-05-29 at 13 20 15" src="https://github.com/user-attachments/assets/8309a90b-d22f-4a46-8a10-13b3335661f4" />

To change the order of phases, specify the parameter `-DturboTestCompile` in the command line arguments or in `.mvn/maven.config`.

This also allows usage of `test-jar` packaging if needed.