### PR TITLE
Support Maven 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,11 @@
             <artifactId>maven-core</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <!--test-->
         <dependency>

--- a/src/main/java/com/github/seregamorph/maven/turbo/TurboMojoExecutionListener.java
+++ b/src/main/java/com/github/seregamorph/maven/turbo/TurboMojoExecutionListener.java
@@ -1,6 +1,6 @@
 package com.github.seregamorph.maven.turbo;
 
-import static com.github.seregamorph.maven.turbo.DefaultLifecyclePatcher.isAnyTest;
+import static com.github.seregamorph.maven.turbo.PhaseOrderPatcher.isAnyTest;
 
 import javax.inject.Named;
 import javax.inject.Singleton;

--- a/src/test/java/com/github/seregamorph/maven/turbo/PhaseOrderPatcherTest.java
+++ b/src/test/java/com/github/seregamorph/maven/turbo/PhaseOrderPatcherTest.java
@@ -1,19 +1,19 @@
 package com.github.seregamorph.maven.turbo;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Sergey Chernov
  */
-class DefaultLifecyclePatcherTest {
+class PhaseOrderPatcherTest {
 
     @Test
-    public void shouldPatchDefaultLifecycleNoTestJarSupported() {
+    public void shouldReorderPhasesNoTestJarSupported() {
         var phases = new ArrayList<>(List.of(
             "validate",
             "initialize",
@@ -39,7 +39,7 @@ class DefaultLifecyclePatcherTest {
             "install",
             "deploy"
         ));
-        DefaultLifecyclePatcher.patchDefaultLifecycle(new TurboBuilderConfig(false), phases);
+        PhaseOrderPatcher.reorderPhases(new TurboBuilderConfig(false), phases, Function.identity());
         assertEquals(List.of(
             "validate",
             "initialize",
@@ -68,7 +68,7 @@ class DefaultLifecyclePatcherTest {
     }
 
     @Test
-    public void shouldPatchDefaultLifecycleTestJarSupported() {
+    public void shouldReorderPhasesTestJarSupported() {
         var phases = new ArrayList<>(List.of(
             "validate",
             "initialize",
@@ -94,7 +94,7 @@ class DefaultLifecyclePatcherTest {
             "install",
             "deploy"
         ));
-        DefaultLifecyclePatcher.patchDefaultLifecycle(new TurboBuilderConfig(true), phases);
+        PhaseOrderPatcher.reorderPhases(new TurboBuilderConfig(true), phases, Function.identity());
         assertEquals(List.of(
             "validate",
             "initialize",

--- a/src/test/java/com/github/seregamorph/maven/turbo/TurboMojosExecutionStrategyMaven3Test.java
+++ b/src/test/java/com/github/seregamorph/maven/turbo/TurboMojosExecutionStrategyMaven3Test.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
  * @author Sergey Chernov
  */
 @SuppressWarnings("CodeBlock2Expr")
-class TurboMojosExecutionStrategyTest {
+class TurboMojosExecutionStrategyMaven3Test {
 
     @Test
     public void shouldReorderAndSignalFullPhasesNoTestJarSupported() throws LifecycleExecutionException {
@@ -194,7 +194,13 @@ class TurboMojosExecutionStrategyTest {
 
         var strategy = new DefaultMojosExecutionStrategy();
         var eventsList = new ArrayList<String>();
-        var turboProjectExecutionListener = new TurboProjectExecutionListener();
+        var turboBuilderConfig = new TurboBuilderConfig(session);
+        var turboProjectExecutionListener = new TurboProjectExecutionListener(turboBuilderConfig) {
+            @Override
+            boolean isReorderPhases() {
+                return false;
+            }
+        };
         var turboMojoExecutionListener = new TurboMojoExecutionListener();
         var mojoRunner = new MojoExecutionRunner() {
             @Override


### PR DESCRIPTION
Maven 4 does not allow to patch `DefaultLifecycles` object.
Instead, the `TurboProjectExecutionListener.beforeProjectLifecycleExecution` will reorder `MojoExecution` objects just before the execution cycle.
This could be the main strategy for both Maven 3 and 4, but the disadvantage of this solution is wrong behavior of `org.codehaus.mojo:buildplan-maven-plugin:list` which will show wrong order or phases (after merging this PR it will show wrong order only in Maven 4).