### PR TITLE
Automatic support of test-jar packaging

### DIFF
--- a/src/main/java/com/github/seregamorph/maven/turbo/TestJarSupport.java
+++ b/src/main/java/com/github/seregamorph/maven/turbo/TestJarSupport.java
@@ -1,0 +1,26 @@
+package com.github.seregamorph.maven.turbo;
+
+import java.util.List;
+import org.apache.maven.plugin.MojoExecution;
+
+/**
+ * @author Sergey Chernov
+ */
+class TestJarSupport {
+
+    static boolean hasTestJar(List<MojoExecution> mojoExecutions) {
+        // test-jar is a special case, because package phase is now executed before compiling tests;
+        // hence make an exception
+        for (MojoExecution mojoExecution : mojoExecutions) {
+            if ("org.apache.maven.plugins".equals(mojoExecution.getGroupId())
+                && "maven-jar-plugin".equals(mojoExecution.getArtifactId())
+                && "test-jar".equals(mojoExecution.getGoal())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private TestJarSupport() {
+    }
+}

--- a/src/main/java/com/github/seregamorph/maven/turbo/TurboLifecycleExecutor.java
+++ b/src/main/java/com/github/seregamorph/maven/turbo/TurboLifecycleExecutor.java
@@ -102,7 +102,9 @@ public class TurboLifecycleExecutor implements LifecycleExecutor {
         if (TurboBuilder.isTurboBuilder(session)) {
             TurboBuilderConfig config = TurboBuilderConfig.fromSession(session);
             List<MojoExecution> mojoExecutions = defaultExecutionPlan.getMojoExecutions();
-            PhaseOrderPatcher.reorderPhases(config.isTurboTestCompile(), mojoExecutions, MojoUtils::getMojoPhase);
+            boolean compileTestsBeforePackage = config.isTurboTestCompile()
+                || TestJarSupport.hasTestJar(mojoExecutions);
+            PhaseOrderPatcher.reorderPhases(compileTestsBeforePackage, mojoExecutions, MojoUtils::getMojoPhase);
             List<ExecutionPlanItem> executionPlanItems = new ArrayList<>();
             for (MojoExecution mojoExecution : mojoExecutions) {
                 executionPlanItems.add(new ExecutionPlanItem(mojoExecution));

--- a/src/main/java/com/github/seregamorph/maven/turbo/TurboMavenLifecycleParticipant.java
+++ b/src/main/java/com/github/seregamorph/maven/turbo/TurboMavenLifecycleParticipant.java
@@ -3,9 +3,7 @@ package com.github.seregamorph.maven.turbo;
 import static com.github.seregamorph.maven.turbo.MavenPropertyUtils.getProperty;
 import static com.github.seregamorph.maven.turbo.MavenPropertyUtils.isTrue;
 
-import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.maven.AbstractMavenLifecycleParticipant;
@@ -13,9 +11,6 @@ import org.apache.maven.MavenExecutionException;
 import org.apache.maven.SessionScoped;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.lifecycle.DefaultLifecycles;
-import org.apache.maven.model.Plugin;
-import org.apache.maven.model.PluginExecution;
-import org.apache.maven.project.MavenProject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +40,6 @@ public class TurboMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
     @Override
     public void afterProjectsRead(MavenSession session) throws MavenExecutionException {
         if (TurboBuilder.isTurboBuilder(session)) {
-            checkTestJarArtifacts(session);
             checkBuilderAndPhase(session);
         }
     }
@@ -54,37 +48,6 @@ public class TurboMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
     public void afterSessionEnd(MavenSession session) {
         if (TurboBuilder.isTurboBuilder(session)) {
             checkBuilderAndPhase(session);
-        }
-    }
-
-    private void checkTestJarArtifacts(MavenSession session) throws MavenExecutionException {
-        TurboBuilderConfig config = TurboBuilderConfig.fromSession(session);
-        if (!config.isTurboTestCompile()) {
-            // test-jar is not supported, because package phase is now executed before compiling tests
-            for (MavenProject project : session.getProjects()) {
-                List<Plugin> jarPlugins = project.getBuildPlugins().stream()
-                    .filter(plugin ->
-                        "org.apache.maven.plugins".equals(plugin.getGroupId())
-                            && "maven-jar-plugin".equals(plugin.getArtifactId()))
-                    .collect(Collectors.toList());
-                for (Plugin jarPlugin : jarPlugins) {
-                    for (PluginExecution pluginExecution : jarPlugin.getExecutions()) {
-                        if (hasTestJarGoal(pluginExecution)) {
-                            throw new MavenExecutionException("Maven started with turbo builder (`-b turbo` CLI "
-                                + "parameter or `-bturbo` in .mvn/maven.config) and it's not compatible with " + project
-                                + " test-jar project artifacts and dependencies because of build phase reordering "
-                                + "(package phase is now executed before compiling tests). The maven-jar-plugin "
-                                + "configuration of the project has configured `test-jar` goal.\n"
-                                + "This can be solved in several ways:\n"
-                                + "1. Get rid of test-jar packaging if possible\n"
-                                + "2. Disable test-jar goal execution when turbo builder is enabled\n"
-                                + "3. Opt-in support of test-jar packaging via `-DturboTestCompile` CLI parameter "
-                                + "or specified in .mvn/maven.config on a separate line",
-                                project.getFile());
-                        }
-                    }
-                }
-            }
         }
     }
 
@@ -114,15 +77,5 @@ public class TurboMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
                 skippedReorderedPhases,
                 config.isTurboTestCompile() ? "" : "To compile tests, run with parameter `-DturboTestCompile`.\n");
         }
-    }
-
-    private boolean hasTestJarGoal(PluginExecution pluginExecution) {
-        // As well as checking for the test-jar goal also check it's bound to a phase
-        // that actually exists as a common pattern to disable the goal when it's
-        // defined in a parent pom is to use a goal like 'none' or 'never'.
-        // Note: phase "null" means the default goal phase (package)
-        String phase = pluginExecution.getPhase();
-        return pluginExecution.getGoals().contains("test-jar")
-            && (phase == null || lifecyclePhases.contains(phase));
     }
 }

--- a/src/main/java/com/github/seregamorph/maven/turbo/TurboProjectExecutionListener.java
+++ b/src/main/java/com/github/seregamorph/maven/turbo/TurboProjectExecutionListener.java
@@ -2,11 +2,13 @@ package com.github.seregamorph.maven.turbo;
 
 import static com.github.seregamorph.maven.turbo.PhaseOrderPatcher.isPackage;
 
+import java.util.List;
 import java.util.stream.Collectors;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import org.apache.maven.execution.ProjectExecutionEvent;
 import org.apache.maven.execution.ProjectExecutionListener;
+import org.apache.maven.plugin.MojoExecution;
 
 /**
  * @author Sergey Chernov
@@ -22,7 +24,8 @@ public class TurboProjectExecutionListener implements ProjectExecutionListener {
     @Override
     public void beforeProjectLifecycleExecution(ProjectExecutionEvent event) {
         CurrentProjectExecution.ifPresent(execution -> {
-            execution.packageMojos = event.getExecutionPlan().stream()
+            List<MojoExecution> mojoExecutions = event.getExecutionPlan();
+            execution.packageMojos = mojoExecutions.stream()
                 .filter(mojo -> {
                     String lifecyclePhase = mojo.getLifecyclePhase();
                     return lifecyclePhase != null && isPackage(lifecyclePhase);
@@ -30,8 +33,9 @@ public class TurboProjectExecutionListener implements ProjectExecutionListener {
                 .collect(Collectors.toList());
 
             TurboBuilderConfig config = TurboBuilderConfig.fromSession(event.getSession());
-            PhaseOrderPatcher.reorderPhases(config.isTurboTestCompile(), event.getExecutionPlan(),
-                MojoUtils::getMojoPhase);
+            boolean compileTestsBeforePackage = config.isTurboTestCompile()
+                || TestJarSupport.hasTestJar(mojoExecutions);
+            PhaseOrderPatcher.reorderPhases(compileTestsBeforePackage, mojoExecutions, MojoUtils::getMojoPhase);
         });
     }
 

--- a/src/test/java/com/github/seregamorph/maven/turbo/TurboMojosExecutionStrategyMaven3Test.java
+++ b/src/test/java/com/github/seregamorph/maven/turbo/TurboMojosExecutionStrategyMaven3Test.java
@@ -13,6 +13,8 @@ import org.apache.maven.lifecycle.LifecycleExecutionException;
 import org.apache.maven.plugin.DefaultMojosExecutionStrategy;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionRunner;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
 
@@ -75,7 +77,7 @@ class TurboMojosExecutionStrategyMaven3Test {
             "exec:install",
             "exec:deploy"
         );
-        shouldReorderAndSignalImpl(phases, expectedEvents);
+        shouldReorderAndSignalImpl(false, phases, expectedEvents);
     }
 
     @Test
@@ -114,15 +116,15 @@ class TurboMojosExecutionStrategyMaven3Test {
             "exec:process-resources",
             "exec:compile",
             "exec:process-classes",
-            "exec:prepare-package",
-            "exec:package",
-            "signal",
             "exec:generate-test-sources",
             "exec:process-test-sources",
             "exec:generate-test-resources",
             "exec:process-test-resources",
             "exec:test-compile",
             "exec:process-test-classes",
+            "exec:prepare-package",
+            "exec:package",
+            "signal",
             "exec:test",
             "exec:pre-integration-test",
             "exec:integration-test",
@@ -131,7 +133,7 @@ class TurboMojosExecutionStrategyMaven3Test {
             "exec:install",
             "exec:deploy"
         );
-        shouldReorderAndSignalImpl(phases, expectedEvents);
+        shouldReorderAndSignalImpl(true, phases, expectedEvents);
     }
 
     @Test
@@ -173,13 +175,25 @@ class TurboMojosExecutionStrategyMaven3Test {
             "exec:test"
         );
 
-        shouldReorderAndSignalImpl(phases, expectedEvents);
+        shouldReorderAndSignalImpl(false, phases, expectedEvents);
     }
 
-    private static void shouldReorderAndSignalImpl(List<String> phases, List<String> expectedEvents) throws LifecycleExecutionException {
+    private static void shouldReorderAndSignalImpl(
+        boolean hasTestJar,
+        List<String> phases,
+        List<String> expectedEvents
+    ) throws LifecycleExecutionException {
         var executionPlan = phases.stream()
             .map(phase -> {
-                var execution = new MojoExecution(null);
+                var mojoDescriptor = new MojoDescriptor();
+                var pluginDescriptor = new PluginDescriptor();
+                mojoDescriptor.setPluginDescriptor(pluginDescriptor);
+                if (hasTestJar && "package".equals(phase)) {
+                    pluginDescriptor.setGroupId("org.apache.maven.plugins");
+                    pluginDescriptor.setArtifactId("maven-jar-plugin");
+                    mojoDescriptor.setGoal("test-jar");
+                }
+                var execution = new MojoExecution(mojoDescriptor);
                 execution.setLifecyclePhase(phase);
                 return execution;
             })


### PR DESCRIPTION
We do not want to encourage usages of `test-jar` dependencies, as well as block them.
In the previous implementation it was possible to have `test-jar` goal executions of `maven-jar-plugin` when `-DturboTestCompile=true` parameter is set. Now it's redundant: if the goal is in the list of mojo executions, automatically includes compilation not only `main`, but also `test` before `package` phase (note: tests are still executed after package to boost the build parallelism)